### PR TITLE
Feat: 게임 디테일 즐겨찾기 api 연동, 링크 복사 구현, 각각의 버튼에 대한 공용 모달 적용

### DIFF
--- a/src/api/game.ts
+++ b/src/api/game.ts
@@ -102,3 +102,10 @@ export const searchGame = async (keyword: string) => {
     throw error;
   }
 };
+
+/**
+ * 게임 즐겨찾기
+ */
+export const postBookMark = async (gamePk: number | undefined) => {
+  sparta_games_auth.post(`/games/api/list/${gamePk}/like/`);
+};

--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -1,21 +1,13 @@
 import { TReviewInputForm } from "../types";
 import { sparta_games_auth } from "./axios";
 
-export const postGameReviews = async (id: number, data: TReviewInputForm, accessToken: string | null) => {
+export const postGameReviews = async (id: number, data: TReviewInputForm) => {
   try {
-    const res = await sparta_games_auth.post(
-      `/games/api/list/${id}/reviews/`,
-      {
-        content: data.content,
-        star: data.star,
-        difficulty: data.difficulty,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
+    const res = await sparta_games_auth.post(`/games/api/list/${id}/reviews/`, {
+      content: data.content,
+      star: data.star,
+      difficulty: data.difficulty,
+    });
     console.log("Response:", res);
     return res;
   } catch (error) {

--- a/src/components/HomeComponents/Hero.tsx
+++ b/src/components/HomeComponents/Hero.tsx
@@ -73,6 +73,7 @@ const Hero = () => {
       {userData && data?.results && data?.results?.length !== 0 && (
         <section className="flex flex-col items-center w-full h-[475px]  text-white justify-center gap-4 mb-10 bg-red-500 ">
           <Swiper
+            className="heroSwiper"
             ref={swiperRef}
             loop={data?.results?.length > 1 ? true : false}
             pagination={{

--- a/src/components/HomeComponents/HeroSwiper.css
+++ b/src/components/HomeComponents/HeroSwiper.css
@@ -1,9 +1,9 @@
-.swiper {
+.heroSwiper {
   width: 100%;
   height: 100%;
 }
 
-.swiper-slide img {
+.heroSwiper .swiper-slide img {
   width: auto !important;
   height: auto !important;
   object-fit: fill !important;

--- a/src/components/gameDetailComponents/GamePlaySection/GameMedia.tsx
+++ b/src/components/gameDetailComponents/GamePlaySection/GameMedia.tsx
@@ -43,7 +43,7 @@ const GameMedia = ({ youtubeUrl, screenShot }: Props) => {
               pagination={{
                 clickable: true,
               }}
-              // autoplay={{ delay: 2000, disableOnInteraction: false }}
+              autoplay={{ delay: 2000, disableOnInteraction: false }}
               modules={[Autoplay]}
             >
               {screenShot.map((image, index) => (

--- a/src/components/gameDetailComponents/GamePlaySection/GameMedia.tsx
+++ b/src/components/gameDetailComponents/GamePlaySection/GameMedia.tsx
@@ -34,6 +34,7 @@ const GameMedia = ({ youtubeUrl, screenShot }: Props) => {
         <div className="h-[340px] overflow-hidden cursor-pointer">
           {screenShot && (
             <Swiper
+              className="gamescreenShotSwiper"
               ref={swiperRef}
               direction={"vertical"}
               loop={true}
@@ -42,17 +43,13 @@ const GameMedia = ({ youtubeUrl, screenShot }: Props) => {
               pagination={{
                 clickable: true,
               }}
-              autoplay={{ delay: 2000, disableOnInteraction: false }}
+              // autoplay={{ delay: 2000, disableOnInteraction: false }}
               modules={[Autoplay]}
             >
               {screenShot.map((image, index) => (
                 <SwiperSlide key={index}>
                   <div className="flex justify-center">
-                    <img
-                      className="w-[198px] h-[112px] rounded-lg"
-                      src={import.meta.env.VITE_PROXY_HOST + image.src}
-                      alt={`carousel-img-${index}`}
-                    />
+                    <img src={import.meta.env.VITE_PROXY_HOST + image.src} alt={`carousel-img-${index}`} />
                   </div>
                 </SwiperSlide>
               ))}

--- a/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
+++ b/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
@@ -18,7 +18,15 @@ type Props = {
 
 const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
   const BOOK_MARK_MODAL_ID = "bookMarkModal";
-  const { modalToggles, onClickModalToggleHandlers } = useModalToggles([BOOK_MARK_MODAL_ID]);
+  const LINK_COPY_MODAL_ID = "LinkCopyModal";
+  const RANDOM_GAME_PICK_ID = "randomGamePickModal";
+
+  const { modalToggles, onClickModalToggleHandlers } = useModalToggles([
+    BOOK_MARK_MODAL_ID,
+    LINK_COPY_MODAL_ID,
+    RANDOM_GAME_PICK_ID,
+  ]);
+
   const [isBookmarked, setIsBookmarked] = useState(false);
 
   const gameUrl = `${import.meta.env.VITE_PROXY_HOST}${gamePath}/index.html`;
@@ -43,6 +51,16 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
     bookMarkMutation.mutate(gamePk);
   };
 
+  const handleLinkCopy = () => {
+    navigator.clipboard.writeText(window.location.href);
+
+    onClickModalToggleHandlers[LINK_COPY_MODAL_ID]();
+  };
+
+  const handleRandomGamePick = () => {
+    onClickModalToggleHandlers[RANDOM_GAME_PICK_ID]();
+  };
+
   return (
     <div className="w-[880px]">
       <div className="flex flex-col gap-2 font-DungGeunMo text-[32px] text-white">
@@ -51,8 +69,8 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
           <p className="text-gray-100 text-[28px]">[{makerNmae}]</p>
           <div className="flex gap-6">
             <img src={bookmark} alt="즐겨찾기" onClick={handleBookMark} className="cursor-pointer" />
-            <img src={share} alt="링크 공유" className="cursor-pointer" />
-            <img src={randomgame} alt="랜덤 게임 추천" className="cursor-pointer" />
+            <img src={share} alt="링크 공유" onClick={handleLinkCopy} className="cursor-pointer" />
+            <img src={randomgame} alt="랜덤 게임 추천" onClick={handleRandomGamePick} className="cursor-pointer" />
             <img src={expand} onClick={handleFullscreen} alt="전체화면" className="cursor-pointer" />
           </div>
         </div>
@@ -68,7 +86,7 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
         title={isBookmarked ? "즐겨찾기 완료" : "즐겨찾기 취소"}
         content={
           isBookmarked
-            ? "즐겨찾기가 성공적으로 완료되었어요. 즐겨찾기한 게임은 마이페이지에서 확인 가능합니다."
+            ? "즐겨찾기가 성공적으로 완료되었어요.<br/>즐겨찾기한 게임은 마이페이지에서 확인 가능합니다."
             : "즐겨찾기가 취소되었습니다."
         }
         type={isBookmarked ? "primary" : "error"}
@@ -76,6 +94,35 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
           text: "확인했습니다",
           onClick: () => {
             onClickModalToggleHandlers[BOOK_MARK_MODAL_ID]();
+          },
+        }}
+      />
+
+      <SpartaReactionModal
+        isOpen={modalToggles[LINK_COPY_MODAL_ID]}
+        onClose={onClickModalToggleHandlers[LINK_COPY_MODAL_ID]}
+        modalId={LINK_COPY_MODAL_ID}
+        title={"링크복사 완료"}
+        content={"게임링크가 성공적으로 복사되었어요.<br/>원하시는 곳에서 붙여넣기 하여 게임을 공유해보세요."}
+        btn1={{
+          text: "확인했습니다",
+          onClick: () => {
+            onClickModalToggleHandlers[LINK_COPY_MODAL_ID]();
+          },
+        }}
+      />
+
+      <SpartaReactionModal
+        isOpen={modalToggles[RANDOM_GAME_PICK_ID]}
+        onClose={onClickModalToggleHandlers[RANDOM_GAME_PICK_ID]}
+        modalId={RANDOM_GAME_PICK_ID}
+        title={"개발예정 기능"}
+        content={"게임 랜덤 추천 기능은 개발 예정입니다."}
+        type={"error"}
+        btn1={{
+          text: "확인했습니다",
+          onClick: () => {
+            onClickModalToggleHandlers[RANDOM_GAME_PICK_ID]();
           },
         }}
       />

--- a/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
+++ b/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
@@ -1,12 +1,13 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 import expand from "../../../assets/gameDetail/expand.svg";
 import share from "../../../assets/gameDetail/linkshare.svg";
 import bookmark from "../../../assets/gameDetail/bookmark.svg";
 import randomgame from "../../../assets/gameDetail/randomgame.svg";
-import { sparta_games_auth } from "../../../api/axios";
 import { useMutation } from "@tanstack/react-query";
 import { postBookMark } from "../../../api/game";
+import SpartaReactionModal from "../../../spartaDesignSystem/SpartaReactionModal";
+import useModalToggles from "../../../hook/useModalToggles";
 
 type Props = {
   gamePk?: number;
@@ -16,6 +17,10 @@ type Props = {
 };
 
 const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
+  const BOOK_MARK_MODAL_ID = "bookMarkModal";
+  const { modalToggles, onClickModalToggleHandlers } = useModalToggles([BOOK_MARK_MODAL_ID]);
+  const [isBookmarked, setIsBookmarked] = useState(false);
+
   const gameUrl = `${import.meta.env.VITE_PROXY_HOST}${gamePath}/index.html`;
   const fullScreenRef = useRef<HTMLDivElement>(null);
 
@@ -26,10 +31,11 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
   const bookMarkMutation = useMutation({
     mutationFn: (gamePk: number | undefined) => postBookMark(gamePk),
     onSuccess: () => {
-      console.log("즐겨찾기 완료했습니다.");
+      setIsBookmarked((prev) => !prev);
+      onClickModalToggleHandlers[BOOK_MARK_MODAL_ID]();
     },
     onError: () => {
-      console.log("즐겨찾기에 실패했습니다. 잠시후에 다시 시도해주세요.");
+      window.alert("즐겨찾기에 실패했습니다. 잠시후에 다시 시도해주세요.");
     },
   });
 
@@ -54,6 +60,25 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
       <div className="mt-5 w-full h-[560px] bg-gray-400 rounded-xl" ref={fullScreenRef}>
         <iframe src={gameUrl} width="100%" height="100%" className="rounded-xl" />
       </div>
+
+      <SpartaReactionModal
+        isOpen={modalToggles[BOOK_MARK_MODAL_ID]}
+        onClose={onClickModalToggleHandlers[BOOK_MARK_MODAL_ID]}
+        modalId={BOOK_MARK_MODAL_ID}
+        title={isBookmarked ? "즐겨찾기 완료" : "즐겨찾기 취소"}
+        content={
+          isBookmarked
+            ? "즐겨찾기가 성공적으로 완료되었어요. 즐겨찾기한 게임은 마이페이지에서 확인 가능합니다."
+            : "즐겨찾기가 취소되었습니다."
+        }
+        type={isBookmarked ? "primary" : "error"}
+        btn1={{
+          text: "확인했습니다",
+          onClick: () => {
+            onClickModalToggleHandlers[BOOK_MARK_MODAL_ID]();
+          },
+        }}
+      />
     </div>
   );
 };

--- a/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
+++ b/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
@@ -4,19 +4,37 @@ import expand from "../../../assets/gameDetail/expand.svg";
 import share from "../../../assets/gameDetail/linkshare.svg";
 import bookmark from "../../../assets/gameDetail/bookmark.svg";
 import randomgame from "../../../assets/gameDetail/randomgame.svg";
+import { sparta_games_auth } from "../../../api/axios";
+import { useMutation } from "@tanstack/react-query";
+import { postBookMark } from "../../../api/game";
 
 type Props = {
+  gamePk?: number;
   title?: string;
   makerNmae?: string;
   gamePath?: string;
 };
 
-const GamePlay = ({ title, makerNmae, gamePath }: Props) => {
+const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
   const gameUrl = `${import.meta.env.VITE_PROXY_HOST}${gamePath}/index.html`;
   const fullScreenRef = useRef<HTMLDivElement>(null);
 
   const handleFullscreen = () => {
     fullScreenRef.current?.requestFullscreen();
+  };
+
+  const bookMarkMutation = useMutation({
+    mutationFn: (gamePk: number | undefined) => postBookMark(gamePk),
+    onSuccess: () => {
+      console.log("즐겨찾기 완료했습니다.");
+    },
+    onError: () => {
+      console.log("즐겨찾기에 실패했습니다. 잠시후에 다시 시도해주세요.");
+    },
+  });
+
+  const handleBookMark = () => {
+    bookMarkMutation.mutate(gamePk);
   };
 
   return (
@@ -26,7 +44,7 @@ const GamePlay = ({ title, makerNmae, gamePath }: Props) => {
         <div className="flex justify-between">
           <p className="text-gray-100 text-[28px]">[{makerNmae}]</p>
           <div className="flex gap-6">
-            <img src={bookmark} alt="즐겨찾기" className="cursor-pointer" />
+            <img src={bookmark} alt="즐겨찾기" onClick={handleBookMark} className="cursor-pointer" />
             <img src={share} alt="링크 공유" className="cursor-pointer" />
             <img src={randomgame} alt="랜덤 게임 추천" className="cursor-pointer" />
             <img src={expand} onClick={handleFullscreen} alt="전체화면" className="cursor-pointer" />

--- a/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
+++ b/src/components/gameDetailComponents/GamePlaySection/GamePlay.tsx
@@ -6,7 +6,7 @@ import bookmark from "../../../assets/gameDetail/bookmark.svg";
 import randomgame from "../../../assets/gameDetail/randomgame.svg";
 import { useMutation } from "@tanstack/react-query";
 import { postBookMark } from "../../../api/game";
-import SpartaReactionModal from "../../../spartaDesignSystem/SpartaReactionModal";
+import SpartaReactionModal, { TSpartaReactionModalProps } from "../../../spartaDesignSystem/SpartaReactionModal";
 import useModalToggles from "../../../hook/useModalToggles";
 
 type Props = {
@@ -18,18 +18,40 @@ type Props = {
 
 const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
   const BOOK_MARK_MODAL_ID = "bookMarkModal";
-  const LINK_COPY_MODAL_ID = "LinkCopyModal";
-  const RANDOM_GAME_PICK_ID = "randomGamePickModal";
+  const NO_ACTION_MODAL_ID = "noActionModal";
 
-  const { modalToggles, onClickModalToggleHandlers } = useModalToggles([
-    BOOK_MARK_MODAL_ID,
-    LINK_COPY_MODAL_ID,
-    RANDOM_GAME_PICK_ID,
-  ]);
+  const { modalToggles, onClickModalToggleHandlers } = useModalToggles([BOOK_MARK_MODAL_ID, NO_ACTION_MODAL_ID]);
 
   const [isBookmarked, setIsBookmarked] = useState(false);
 
+  const noActionData: { [key: string]: Partial<TSpartaReactionModalProps> } = {
+    linkcopy: {
+      title: "링크복사 완료",
+      content: "게임링크가 성공적으로 복사되었어요.<br/>원하시는 곳에서 붙여넣기 하여 게임을 공유해보세요.",
+      btn1: {
+        text: "확인했습니다",
+        onClick: () => {
+          onClickModalToggleHandlers[NO_ACTION_MODAL_ID]();
+        },
+      },
+    },
+    randomgamepick: {
+      title: "개발예정 기능",
+      content: "게임 랜덤 추천 기능은 개발 예정입니다.",
+      btn1: {
+        text: "확인했습니다",
+        onClick: () => {
+          onClickModalToggleHandlers[NO_ACTION_MODAL_ID]();
+        },
+      },
+      type: "error",
+    },
+  };
+
+  const [noActionModalData, setNoActionModalData] = useState<Partial<TSpartaReactionModalProps>>(noActionData.linkcopy);
+
   const gameUrl = `${import.meta.env.VITE_PROXY_HOST}${gamePath}/index.html`;
+
   const fullScreenRef = useRef<HTMLDivElement>(null);
 
   const handleFullscreen = () => {
@@ -54,11 +76,13 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
   const handleLinkCopy = () => {
     navigator.clipboard.writeText(window.location.href);
 
-    onClickModalToggleHandlers[LINK_COPY_MODAL_ID]();
+    setNoActionModalData(noActionData.linkcopy);
+    onClickModalToggleHandlers[NO_ACTION_MODAL_ID]();
   };
 
   const handleRandomGamePick = () => {
-    onClickModalToggleHandlers[RANDOM_GAME_PICK_ID]();
+    setNoActionModalData(noActionData.randomgamepick);
+    onClickModalToggleHandlers[NO_ACTION_MODAL_ID]();
   };
 
   return (
@@ -98,34 +122,20 @@ const GamePlay = ({ gamePk, title, makerNmae, gamePath }: Props) => {
         }}
       />
 
-      <SpartaReactionModal
-        isOpen={modalToggles[LINK_COPY_MODAL_ID]}
-        onClose={onClickModalToggleHandlers[LINK_COPY_MODAL_ID]}
-        modalId={LINK_COPY_MODAL_ID}
-        title={"링크복사 완료"}
-        content={"게임링크가 성공적으로 복사되었어요.<br/>원하시는 곳에서 붙여넣기 하여 게임을 공유해보세요."}
-        btn1={{
-          text: "확인했습니다",
-          onClick: () => {
-            onClickModalToggleHandlers[LINK_COPY_MODAL_ID]();
-          },
-        }}
-      />
-
-      <SpartaReactionModal
-        isOpen={modalToggles[RANDOM_GAME_PICK_ID]}
-        onClose={onClickModalToggleHandlers[RANDOM_GAME_PICK_ID]}
-        modalId={RANDOM_GAME_PICK_ID}
-        title={"개발예정 기능"}
-        content={"게임 랜덤 추천 기능은 개발 예정입니다."}
-        type={"error"}
-        btn1={{
-          text: "확인했습니다",
-          onClick: () => {
-            onClickModalToggleHandlers[RANDOM_GAME_PICK_ID]();
-          },
-        }}
-      />
+      {noActionModalData && (
+        <SpartaReactionModal
+          isOpen={modalToggles[NO_ACTION_MODAL_ID]}
+          onClose={onClickModalToggleHandlers[NO_ACTION_MODAL_ID]}
+          modalId={NO_ACTION_MODAL_ID}
+          title={noActionModalData.title || ""}
+          content={noActionModalData.content || ""}
+          btn1={{
+            text: noActionModalData?.btn1?.text || "",
+            onClick: noActionModalData?.btn1?.onClick || (() => {}),
+          }}
+          type={noActionModalData.type}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/gameDetailComponents/GamePlaySection/GamePlaySection.tsx
+++ b/src/components/gameDetailComponents/GamePlaySection/GamePlaySection.tsx
@@ -11,13 +11,13 @@ type Props = {
 };
 
 const GamePlaySection = ({ gamePlayData }: Props) => {
-  const { title, maker_name, gamepath, youtube_url, screenshot, content } = gamePlayData || {};
+  const { id, title, maker_name, gamepath, youtube_url, screenshot, content } = gamePlayData || {};
 
   return (
     <section className="mt-6">
       <div className="flex gap-5">
         {/* TODO: account_user id와 games_game maker_id 동등 여부 통해 수정하기/ 삭제하기 버튼 표시*/}
-        <GamePlay title={title} makerNmae={maker_name} gamePath={gamepath} />
+        <GamePlay gamePk={id} title={title} makerNmae={maker_name} gamePath={gamepath} />
         <GameMedia youtubeUrl={youtube_url} screenShot={screenshot} />
       </div>
       <GameDescription title={title} content={content} screenshot={screenshot} />

--- a/src/components/gameDetailComponents/GamePlaySection/GamePlaySwiper.css
+++ b/src/components/gameDetailComponents/GamePlaySection/GamePlaySwiper.css
@@ -1,15 +1,15 @@
-.swiper {
+.gamescreenShotSwiper {
   @apply w-full h-full;
 }
 
-.swiper-slide {
+.gamescreenShotSwiper .swiper-slide {
   @apply flex justify-center items-center;
 }
 
-.swiper-slide img {
-  @apply block object-cover;
+.gamescreenShotSwiper .swiper-slide img {
+  @apply w-[198px] h-[112px] object-cover rounded-lg;
 }
 
-.swiper-slide-active img {
+.gamescreenShotSwiper .swiper-slide-active img {
   @apply w-[248px] h-[140px] rounded-lg z-10 transition-all duration-500 ease-in-out;
 }

--- a/src/hook/gameDetailHook/useReview.ts
+++ b/src/hook/gameDetailHook/useReview.ts
@@ -33,10 +33,9 @@ const useReview = () => {
   const onSubmitHandler: (id: number, data: TReviewInputForm, accessToken: string | null) => void = async (
     id,
     data,
-    accessToken,
   ) => {
     // difficulty 데이터 유형 integer로 인한 오류 수정 필요
-    await postGameReviews(id, data, accessToken);
+    await postGameReviews(id, data);
   };
 
   const form = {

--- a/src/spartaDesignSystem/SpartaReactionModal.tsx
+++ b/src/spartaDesignSystem/SpartaReactionModal.tsx
@@ -36,8 +36,11 @@ const SpartaReactionModal = ({
   return (
     <SpartaModal isOpen={isOpen} onClose={onClose} modalId={modalId} type={type}>
       <div className="min-w-80 flex flex-col items-center gap-4">
-        <div className={`text-heading-32 font-semibold ${titleColor} font-DungGeunMo`}>{title}</div>
-        <div className="text-title-22 my-10 text-white line-clamp-2">{content}</div>
+        <div className={`text-heading-32 font-medium ${titleColor} font-DungGeunMo`}>{title}</div>
+        <div
+          className="text-title-22 font-light leading-8 my-10 text-white text-center"
+          dangerouslySetInnerHTML={{ __html: content }}
+        ></div>
         {btn2 && <SpartaButton content={btn2.text} onClick={btn2.onClick} type={"filled"} colorType="grey" />}
         <SpartaButton content={btn1.text} onClick={btn1.onClick} type={"filled"} colorType={type} />
       </div>

--- a/src/spartaDesignSystem/SpartaReactionModal.tsx
+++ b/src/spartaDesignSystem/SpartaReactionModal.tsx
@@ -37,7 +37,7 @@ const SpartaReactionModal = ({
     <SpartaModal isOpen={isOpen} onClose={onClose} modalId={modalId} type={type}>
       <div className="min-w-80 flex flex-col items-center gap-4">
         <div className={`text-heading-32 font-semibold ${titleColor} font-DungGeunMo`}>{title}</div>
-        <div className="text-title-22 my-10 text-white">{content}</div>
+        <div className="text-title-22 my-10 text-white line-clamp-2">{content}</div>
         {btn2 && <SpartaButton content={btn2.text} onClick={btn2.onClick} type={"filled"} colorType="grey" />}
         <SpartaButton content={btn1.text} onClick={btn1.onClick} type={"filled"} colorType={type} />
       </div>


### PR DESCRIPTION
## ✨ 개발 내용

즐겨찾기 api 연동 및 동작 확인 했습니다. 그 외에 링크 복사 구현과 공용 모달 적용 완료했습니다.

그런데 공용 모달을 적용할 때 텍스트가 긴 경우에 아래 이미지와 같이 한줄로 쭉 나열되는 이슈가 있었습니다.

![수정전](https://github.com/user-attachments/assets/ee5c47cf-1a4e-4688-9d7c-2fadc6b2bdee)

위 이슈 수정하기 위해서 공용 모달 (SpartaReactionModal)의 content 데이터 바인딩 부분 <div> 태그 내에 dangerouslySetInnerHTML={{ __html: content }} 코드 추가했습니다. 수정된 코드는 6d29ea4 커밋에서 확인 가능합니다!

![수정 후](https://github.com/user-attachments/assets/690cc819-9e4f-4cb2-abb6-8ca4a2df179a)

일단 제 로컬에서 다른 모달들 테스트 했을 때 문제는 없었는데 혹시 몰라 내용 정리해봅니다! 혹시 서현님 작업하시다 디자인적으로 문제가 생기면 편하게 말씀해주세요! 다른 방향으로 수정해보도록 하겠습니다.

 
![링크복사](https://github.com/user-attachments/assets/fdf63516-19c4-4384-b7fe-550b0de5e87c)    ![게임 랜덤 추천](https://github.com/user-attachments/assets/ccdebc73-8e05-47c1-be52-55b3fe4c35ce)

그 외에 공용 모달에서 수정한 부분은 텍스트 정렬 스타일이 안되어 있어서 text-center 추가한 것과 전체적인 글씨 두께 조금 얇게, content 글씨 수직 간격 조금 늘어나게 수정했습니다. 